### PR TITLE
metrics must end with CRLF

### DIFF
--- a/src/so/grep/cyanite/carbon.clj
+++ b/src/so/grep/cyanite/carbon.clj
@@ -35,4 +35,4 @@
     (info "starting carbon handler")
     (tcp/start-tcp-server
      handler
-     (merge carbon {:frame (string :utf-8 :delimiters ["\r\n"])}))))
+     (merge carbon {:frame (string :utf-8 :delimiters ["\r\n" "\n"])}))))


### PR DESCRIPTION
Looks like metrics ending with just a linefeed are ignored:

```
$ DATE=$(date +%s)    
$ echo $DATE
1388498354
$ echo -n "lf 1 $DATE\n"     | ssh mon nc -w1 localhost 2003    
$ echo -n "crlf 1 $DATE\r\n" | ssh mon nc -w1 localhost 2003
```

Back on the cyanite host:

```
cqlsh:metric> select * from metric;

 period | rollup | path | time       | data
--------+--------+------+------------+------
 105120 |    600 | crlf | 1388497800 |  [1]
  60480 |     10 | crlf | 1388498350 |  [1]

(2 rows)
```

Carbon (I tested 0.9.6) accepts both LF and CRLF.
