### PR TITLE
Add keyspace creation to deb postinstall

### DIFF
--- a/pkg/deb/postinst.sh
+++ b/pkg/deb/postinst.sh
@@ -5,3 +5,8 @@ chown root:root /usr/bin/cyanite
 chown cyanite:cyanite /var/log/cyanite
 chown cyanite:cyanite /etc/cyanite.yaml
 chown root:root /etc/init.d/cyanite
+
+if command -v cqlsh > /dev/null 2>&1
+then
+	echo "SELECT path from metric LIMIT 1 ;" | cqlsh -k metric > /dev/null 2>&1 || (echo "Creating cassandra schema..." && cat /var/lib/cyanite/schema.cql | cqlsh)
+fi

--- a/tasks/leiningen/fatdeb.clj
+++ b/tasks/leiningen/fatdeb.clj
@@ -98,6 +98,11 @@
                 (str "cyanite-" (:version project) "-standalone.jar"))
           (file dir "usr" "lib" "cyanite" "cyanite.jar"))
 
+    ; cql schema
+    (.mkdirs (file dir "var" "lib" "cyanite"))
+    (copy (file (:root project) "doc" "schema.cql")
+          (file dir "var" "lib" "cyanite" "schema.cql"))
+
     ; Binary
     (.mkdirs (file dir "usr" "bin"))
     (copy (file (:root project) "pkg" "deb" "cyanite")


### PR DESCRIPTION
```
root@d380e9ae-55cc-4ce2-be30-3e1cc66ee5be:~# dpkg -i cyanite_0.1.0_all.deb 
Selecting previously unselected package cyanite.
(Reading database ... 54455 files and directories currently installed.)
Unpacking cyanite (from cyanite_0.1.0_all.deb) ...
Setting up cyanite (0.1.0) ...
Creating cassandra schema...
Processing triggers for ureadahead ...
root@d380e9ae-55cc-4ce2-be30-3e1cc66ee5be:~# cqlsh -k metric
Connected to Test Cluster at localhost:9160.
[cqlsh 4.1.1 | Cassandra 2.0.6 | CQL spec 3.1.1 | Thrift protocol 19.39.0]
Use HELP for help.
cqlsh:metric> SELECT path from metric limit 1;

(0 rows)

cqlsh:metric>
```
