### PR TITLE
Add a simple /ping route

### DIFF
--- a/src/org/spootnik/cyanite/http.clj
+++ b/src/org/spootnik/cyanite/http.clj
@@ -13,7 +13,8 @@
 (def
   ^{:doc "Our dead simple router"}
   routes [[:paths   #"^/paths.*"]
-          [:metrics #"^/metrics.*"]])
+          [:metrics #"^/metrics.*"]
+          [:ping #"^/ping/?"]])
 
 (defn now
   "Returns a unix epoch"
@@ -78,6 +79,10 @@
                         (if (sequential? path) path [path]))]
       (store/fetch store (or agg "mean") paths rollup period from to))
     {:step nil :from nil :to nil :series {}}))
+
+(defmethod process :ping
+  [_]
+  {})
 
 (defmethod process :default
   [_]


### PR DESCRIPTION
At the moment, when running in EC2, I've got the application load-balancing based on hitting `/paths/?query=*`. This pull request adds a `/ping` route (optional trailing `/` allowed) to avoid using the path in-memory path database more than absolutely necessary.
