### PR TITLE
handle bad numbers in carbon handler

### DIFF
--- a/src/org/spootnik/cyanite/carbon.clj
+++ b/src/org/spootnik/cyanite/carbon.clj
@@ -13,7 +13,7 @@
   default value if it fails"
   [parse default number]
   (try (parse number)
-    (catch NumberFormatException e
+    (catch Exception e
       (debug "got an invalid number" number (.getMessage e))
       default)))
 


### PR DESCRIPTION
Bad numbers in both time and metric fields results in a NumberFormatException, which crashes the channel and seems to cause some performance issues with high load. 

This patch tries to parse the numbers and sets a default "nan" value if its not a valid number, which results in it being skipped
