### PR TITLE
added the ability to handle username//password for cassandra

### DIFF
--- a/src/io/cyanite/store.clj
+++ b/src/io/cyanite/store.clj
@@ -20,7 +20,6 @@
   (channel-for [this])
   (fetch [this agg paths tenant rollup period from to]))
 
-(def not-nil? (complement nil?))
 ;;
 ;; The following contains necessary cassandra queries. Since
 ;; cyanite relies on very few queries, I decided against using


### PR DESCRIPTION
If you add a username/password in the yaml, it can use that to authenticate. If it's not there in the yaml, it will still connect and work.

```
carbon:
  host: "0.0.0.0"
  port: 2003
  rollups:
    - period: 60480
      rollup: 10
    - period: 105120
      rollup: 600
http:
  host: "0.0.0.0"
  port: 8080
logging:
  level: info
  console: true
  files:
    - "/var/log/cyanite.log"
store:
  cluster:
    - "secasprddb01-1"
    - "secasprddb01-2"
  keyspace: 'metric'
  username: "graphite"
  password: "graphite"
```
