### PR TITLE
fix broken json decoding when ElasticSearch returns chunked responses

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -15,7 +15,7 @@
                  [clj-yaml                      "0.4.0"]
                  [clj-http                      "1.0.1"
                   :exclusions [commons-codec]]
-                 [cc.qbits/jet                  "0.5.0-alpha3"]
+                 [cc.qbits/jet                  "0.5.3"]
                  [cc.qbits/alia                 "2.2.2"]
                  [net.jpountz.lz4/lz4           "1.2.0"]
                  [org.xerial.snappy/snappy-java "1.1.1.3"]

--- a/src/io/cyanite/es_client.clj
+++ b/src/io/cyanite/es_client.clj
@@ -21,7 +21,9 @@
   (go
     (let [url  (rest/index-mget-url conn index mapping-type)
           resp (<! (http/post @client url
-                              {:body (json/encode {:docs query}) :as :json}))
+                              {:body (json/encode {:docs query})
+                               :fold-chunked-response? true
+                               :as :json}))
           body (<! (:body resp))]
       (if (= 200 (:status resp))
         (func (filter :found (:docs body)))


### PR DESCRIPTION
see https://github.com/mpenet/jet/blob/master/CHANGELOG.md#053

In short:  the default behavior of jet is to send (and decode) response body chunks in the :body channel piece after piece, so :as :json will not work as expected when used against ElasticSearch which returns chunked response depending on the size of the results. 