### PR TITLE
Metric path Value Lists for ES path lookup

### DIFF
--- a/src/io/cyanite/es_path.clj
+++ b/src/io/cyanite/es_path.clj
@@ -69,7 +69,17 @@
   "generate the filter portion of an es query"
   [path tenant leafs-only]
   (let [depth (path-depth path)
-        p (str/replace (str/replace path "." "\\.") "*" ".*")
+        ; graphite-api: "Comma-separated values within curly braces
+        ;                ({foo,bar,...}) are treated as value list."
+        ; Replace "{a,b}" as "(a|b)" for ElasticSearch query
+        p (-> path
+          (str/replace "," "|")
+          (str/replace "}" ")")
+          (str/replace "{" "(")
+          (str/replace "." "\\.")
+          (str/replace "*" ".*")
+        )
+
         f (vector
            {:range {:depth {:from depth :to depth}}}
            {:term {:tenant tenant}}


### PR DESCRIPTION
Value Lists (`{val1,val2,val3}`) for metric paths are supported in both graphite-web and graphite-api, however this query string cannot be passed directly to ElasticSearch without modification.

Replace "{a,b}" as "(a|b)" to convert to a rudimentary ElasticSearch regex query.

With thanks to @AeroNotix for the clojure help.