### PR TITLE
doc: update quickstart yaml using correct input key

### DIFF
--- a/doc/source/quickstart.rst
+++ b/doc/source/quickstart.rst
@@ -56,11 +56,10 @@ See :ref:`Configuration Syntax` for more details
       console: true
       files:
         - "/var/log/cyanite/cyanite.log"
-    inputs:
+    input:
       - type: "carbon"
       - type: "pickle"
     store:
-      type: "cassandra-v2"
       cluster: "127.0.0.1"
     index:
       type: "memory"


### PR DESCRIPTION
Update the default config yaml with the proper `input` key so that the carbon and pickle listeners start correctly.  Also removed the cassandra store type as that appears to be a default setting now. 