### PR TITLE
Allow :time values from pickle input as Double

### DIFF
--- a/src/io/cyanite/input/pickle.clj
+++ b/src/io/cyanite/input/pickle.clj
@@ -16,7 +16,7 @@
       (for [[val time path] (pickle/ast->metrics ast)]
         {:path   path
          :metric (if (string? val) (Double/parseDouble val) val)
-         :time   (Long. time)}))
+         :time   (long time)}))
     (catch Exception e
       (warn e "cannot deserialize pickle")
       nil)))


### PR DESCRIPTION
Using cyanite with the pickle input and feeding pickled data from carbon (version 0.9.12) we ran into the following exception:

```
IllegalArgumentException No matching ctor found for class java.lang.Long
```

In our case the value which is expected to be the `time` value in the pickled data (produced from `pickle/ast->metrics`) was serialized as a double by carbon. However the double value cannot be converted to a long using the `(Long. time)` form. `(long time)` works though.
