### PR TITLE
cassandra: forward correct credentials.

### DIFF
--- a/src/io/cyanite/index/cassandra.clj
+++ b/src/io/cyanite/index/cassandra.clj
@@ -42,7 +42,7 @@
           cluster (if (sequential? cluster) cluster [cluster])
           session (-> {:contact-points cluster}
                       (cond-> (and username password)
-                        (assoc :credentials {:username username
+                        (assoc :credentials {:user username
                                              :password password}))
                       (alia/cluster)
                       (alia/connect (or (:keyspace opts) "metric")))


### PR DESCRIPTION
Same problem with https://github.com/pyr/cyanite/issues/138 .