### PR TITLE
Update required cassandra version in docs

### DIFF
--- a/doc/source/administrator.rst
+++ b/doc/source/administrator.rst
@@ -207,7 +207,7 @@ operating a large metric cluster.
 Choosing a Cassandra version
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Cyanite will work with Cassandra 2.0 and above, it has been tested
+Cyanite will work with Cassandra 2.1 and above, it has been tested
 with the 2.1 releases extensively and thus is recommended.
 
 Choosing a compaction strategy


### PR DESCRIPTION
Since Cyanite makes use of user-defined types at least Cassandra 2.1 is required.