### PR TITLE
Allow longer first http request lines

### DIFF
--- a/src/io/cyanite/http.clj
+++ b/src/io/cyanite/http.clj
@@ -130,7 +130,7 @@
   (proxy [ChannelInitializer] []
     (initChannel [channel]
       (let [pipeline (.pipeline channel)]
-        (.addLast pipeline "codec"      (HttpServerCodec.))
+        (.addLast pipeline "codec"      (HttpServerCodec. 1048576 8192 8192))
         (.addLast pipeline "aggregator" (HttpObjectAggregator. 1048576))
         (.addLast pipeline "handler"    (netty-handler handler))))))
 


### PR DESCRIPTION
By default Netty only allows 4096 bytes on the first http request line, i.e. including get params. This change makes cyanite allow much longer first lines which sometimes is needed, see e.g. https://github.com/brutasse/graphite-cyanite/issues/16