### PR TITLE
Make it possible to run Grafana multi-metric requests

### DIFF
--- a/src/io/cyanite/api.clj
+++ b/src/io/cyanite/api.clj
@@ -122,7 +122,10 @@
                   (throw (ex-info "missing from parameter"
                                   {:suppress? true :status 400})))
         to    (or (parse-time until) (now!))]
-    (query/run-query! store index engine from to target)))
+    (query/run-query! store index engine from to
+                      (if (seq? target)
+                        target
+                        [target]))))
 
 (defmethod dispatch :metrics
   [{{:keys [from to path agg]} :params :keys [index store engine]}]


### PR DESCRIPTION
Right now, it's only possible to run single queries. It'd be nice to be able to fetch graphs for multiple requests. It might be possible to optimise it somehow though.