### PR TITLE
Stop adding items to result set if there are no more points available.

### DIFF
--- a/src/io/cyanite/query.clj
+++ b/src/io/cyanite/query.clj
@@ -26,7 +26,9 @@
   (loop [res        []
          [d & ds]   data
          point      from]
-    (if d (recur (conj res [d point]) ds (+ point step)) res)))
+    (if ds
+      (recur (if d (conj res [d point]) res) ds (+ point step))
+      res)))
 
 (defn run-query!
   [store index engine from to query]


### PR DESCRIPTION
Previously, the items were not added to result set 
after the first null entry (missing point), which
was leading to lagging graphs for the metrics with
at least one second of lag within the given time
period.

Fixes #170.