### PR TITLE
Split Engine into Ingester and Writer.

### DIFF
--- a/doc/cyanite.yaml
+++ b/doc/cyanite.yaml
@@ -89,6 +89,21 @@ input:
 index:
   type: agent
 ##
+## Drift
+## =====
+##
+## Detects the drift on the agent clock and ensures
+## that the snapshot epoch is calculated correctly
+## despite the time difference between the agent
+## and the calculating machine.
+##
+## Default implementation is `agent`.
+## If you trust your clocks and/or would like to
+## avoid drift handling on Cyanite side, you
+## can opt-out for `no-op` one.
+drift:
+  type: agent
+##
 ## Store
 ## =====
 ##

--- a/src/io/cyanite.clj
+++ b/src/io/cyanite.clj
@@ -14,7 +14,7 @@
             [metrics.reporters.jmx      :as jmx]
             [io.cyanite.engine          :refer [map->Engine]]
             [io.cyanite.engine.writer   :refer [map->Writer]]
-            [io.cyanite.engine.drift    :refer [map->SystemClock map->AgentDrift]]
+            [io.cyanite.engine.drift    :refer [map->SystemClock build-drift]]
             [io.cyanite.api             :refer [map->Api]]
             [unilog.config              :refer [start-logging!]]
             [spootnik.uncaught          :refer [uncaught]]
@@ -62,7 +62,7 @@
           (dissoc :logging)
           (build-components :input input/build-input)
           (update :clock    #(map->SystemClock %))
-          (update :drift    #(component/using (map->AgentDrift %) [:clock]))
+          (update :drift    #(component/using (build-drift %) [:clock]))
           (update :queues   queue/map->BlockingMemoryQueue)
           (update :engine   #(component/using (map->Engine %) [:drift
                                                                :queues

--- a/src/io/cyanite/engine.clj
+++ b/src/io/cyanite/engine.clj
@@ -1,7 +1,6 @@
 (ns io.cyanite.engine
   "The core of cyanite"
-  (:require [io.cyanite.engine          :as engine]
-            [com.stuartsierra.component :as component]
+  (:require [com.stuartsierra.component :as component]
             [io.cyanite.engine.rule     :as rule]
             [io.cyanite.engine.queue    :as q]
             [io.cyanite.engine.buckets  :as b]
@@ -31,7 +30,7 @@
     (time! t-assc
            (assoc-if-absent! buckets k metric-key))
     (doseq [snapshot snaps]
-      (time! t-enq (engine/accept! writer snapshot)))))
+      (time! t-enq (accept! writer snapshot)))))
 
 (defrecord Engine [rules queues ingestq planner drift writer]
   component/Lifecycle
@@ -50,10 +49,10 @@
 
       (assoc this :planner planner :bucket buckets :ingestq ingestq)))
   (stop [this])
-  engine/Acceptor
+  Acceptor
   (accept! [this metric]
     (q/add! ingestq metric))
-  engine/Resolutionator
+  Resolutionator
   (resolution [this oldest path]
     (let [plan (rule/->exec-plan planner {:path path})
           ts   (now!)]

--- a/src/io/cyanite/engine.clj
+++ b/src/io/cyanite/engine.clj
@@ -1,17 +1,14 @@
 (ns io.cyanite.engine
   "The core of cyanite"
-  (:require [com.stuartsierra.component :as component]
+  (:require [io.cyanite.engine          :as engine]
+            [com.stuartsierra.component :as component]
             [io.cyanite.engine.rule     :as rule]
             [io.cyanite.engine.queue    :as q]
             [io.cyanite.engine.buckets  :as b]
-            [io.cyanite.index           :as index]
-            [io.cyanite.store           :as store]
             [io.cyanite.utils           :refer [nbhm assoc-if-absent! now!]]
             [io.cyanite.engine.drift    :refer [drift! skewed-epoch!]]
             [clojure.tools.logging      :refer [info debug]]
-            [metrics.timers             :refer [deftimer time!]]
-            [metrics.core               :refer [new-registry]]
-            [metrics.counters           :refer [inc! dec! defcounter]]))
+            [metrics.timers             :refer [deftimer time!]]))
 
 (deftimer t-tuple)
 (deftimer t-mkey)
@@ -20,13 +17,13 @@
 (deftimer t-enq)
 
 (defprotocol Acceptor
-  (accept! [this metric]))
+  (accept! [this value]))
 
 (defprotocol Resolutionator
   (resolution [this oldest path]))
 
 (defn ingest-at-resolution
-  [drift buckets queues resolution metric]
+  [drift buckets writer resolution metric]
   (let [k          (time! t-tuple (b/tuple resolution (:path metric)))
         metric-key (time! t-mkey (or (get buckets k) (b/metric-key k)))
         snaps      (time! t-snap (b/add-then-snap! metric-key metric
@@ -34,33 +31,29 @@
     (time! t-assc
            (assoc-if-absent! buckets k metric-key))
     (doseq [snapshot snaps]
-      (time! t-enq (q/add! (:writeq queues) snapshot)))))
+      (time! t-enq (engine/accept! writer snapshot)))))
 
-(defrecord Engine [rules planner buckets index store queues drift]
+(defrecord Engine [rules queues ingestq planner drift writer]
   component/Lifecycle
   (start [this]
     (let [buckets (nbhm)
-          planner (map rule/->rule rules)]
+          planner (map rule/->rule rules)
+          ingestq (:ingestq queues)]
       (info "starting engine")
-      (q/consume! (:ingestq queues)
+      (q/consume! ingestq
                   (fn [metric]
                     (drift! drift (:time metric))
                     (let [plan (rule/->exec-plan planner metric)]
                       (doseq [resolution plan]
-                        (ingest-at-resolution drift buckets queues
+                        (ingest-at-resolution drift buckets writer
                                               resolution metric)))))
 
-      (q/consume! (:writeq queues)
-                  (fn [metric]
-                    (index/register! index (:path metric))
-                    (store/insert! store metric)))
-      (assoc this :planner planner :bucket buckets)))
-  (stop [this]
-    (assoc this :planner nil :buckets nil))
-  Acceptor
+      (assoc this :planner planner :bucket buckets :ingestq ingestq)))
+  (stop [this])
+  engine/Acceptor
   (accept! [this metric]
-    (q/add! (:ingestq queues) metric))
-  Resolutionator
+    (q/add! ingestq metric))
+  engine/Resolutionator
   (resolution [this oldest path]
     (let [plan (rule/->exec-plan planner {:path path})
           ts   (now!)]

--- a/src/io/cyanite/engine/drift.clj
+++ b/src/io/cyanite/engine/drift.clj
@@ -43,4 +43,30 @@
   (deref [this]
     @slot))
 
+;; A no-op implementation of the drift,
+;; might be used in test purposes or
+;; to avoid the drift calculation ovrehead
+;; in production systems.
+(defrecord NoOpDrift [clock]
+  component/Lifecycle
+  (start [this] this)
+  (stop [this] this)
+  Drift
+  (drift! [this ts] nil)
+  (skewed-epoch! [this]
+    (epoch! clock))
+  clojure.lang.IDeref
+  (deref [this]
+    0))
+
+(defmulti build-drift (comp (fnil keyword "agent") :type))
+
+(defmethod build-drift :no-op
+  [options]
+  (map->NoOpDrift options))
+
+(defmethod build-drift :agent
+  [options]
+  (map->AgentDrift options))
+
 (prefer-method print-method clojure.lang.IRecord clojure.lang.IDeref)

--- a/src/io/cyanite/engine/writer.clj
+++ b/src/io/cyanite/engine/writer.clj
@@ -1,0 +1,24 @@
+(ns io.cyanite.engine.writer
+  "The core of cyanite"
+  (:require [io.cyanite.engine          :as engine]
+            [com.stuartsierra.component :as component]
+            [io.cyanite.engine.queue    :as q]
+            [io.cyanite.index           :as index]
+            [io.cyanite.store           :as store]
+            [clojure.tools.logging      :refer [info debug]]))
+
+(defrecord Writer [index store queues writeq]
+  component/Lifecycle
+  (start [this]
+    (info "starting writer engine")
+    (let [writeq (:writeq queues)]
+      (q/consume! writeq
+                  (fn [metric]
+                    (index/register! index (:path metric))
+                    (store/insert! store metric)))
+      (assoc this :writeq writeq)))
+  (stop [this]
+    (assoc this))
+  engine/Acceptor
+  (accept! [this metric]
+    (q/add! writeq metric)))

--- a/src/io/cyanite/engine/writer.clj
+++ b/src/io/cyanite/engine/writer.clj
@@ -22,21 +22,3 @@
   engine/Acceptor
   (accept! [this metric]
     (q/add! writeq metric)))
-
-(defn memory-writer
-  "Extremely inefficient in-memory acceptor that writes everything to the internal vector, to be used
-   for testing/mocking purposes"
-  ([]
-   (memory-writer conj))
-  ([f]
-   (let [state (atom [])]
-     (reify
-       component/Lifecycle
-       (start [this] this)
-       (stop [this] this)
-       clojure.lang.IDeref
-       (deref [this]
-         @state)
-       engine/Acceptor
-       (accept! [this metric]
-         (swap! state f metric))))))

--- a/src/io/cyanite/engine/writer.clj
+++ b/src/io/cyanite/engine/writer.clj
@@ -22,3 +22,21 @@
   engine/Acceptor
   (accept! [this metric]
     (q/add! writeq metric)))
+
+(defn memory-writer
+  "Extremely inefficient in-memory acceptor that writes everything to the internal vector, to be used
+   for testing/mocking purposes"
+  ([]
+   (memory-writer conj))
+  ([f]
+   (let [state (atom [])]
+     (reify
+       component/Lifecycle
+       (start [this] this)
+       (stop [this] this)
+       clojure.lang.IDeref
+       (deref [this]
+         @state)
+       engine/Acceptor
+       (accept! [this metric]
+         (swap! state f metric))))))

--- a/test/io/cyanite/engine_test.clj
+++ b/test/io/cyanite/engine_test.clj
@@ -1,0 +1,27 @@
+(ns io.cyanite.engine-test
+  (:require [io.cyanite.engine          :as e]
+            [com.stuartsierra.component :as component]
+            [clojure.test               :refer :all]
+            [io.cyanite.test-helper     :refer :all]))
+
+
+(deftest engine-test
+  (with-config
+    {:engine (component/using (e/map->Engine {:rules {"default" ["5s:1h"]}}) [:drift
+                                                                              :queues
+                                                                              :writer])}
+    (let [engine    (:engine *system*)
+          clock     (:clock *system*)
+          writer    (:writer *system*)
+          base-time 1454877020]
+      (doseq [i (range 0 6)]
+        (set-time! clock (* (+ base-time i) 1000))
+        (e/accept! engine {:path "a.b.c" :metric i :time (+ base-time i)}))
+
+      (let [[res] @writer]
+        (is (= "a.b.c" (:path res)))
+        (is (= 2.0 (:mean res)))
+        (is (= 10 (:sum res)))
+        (is (= 4 (:max res)))
+        (is (= 0 (:min res)))
+        (is (= base-time (:time res)))))))

--- a/test/io/cyanite/test_helper.clj
+++ b/test/io/cyanite/test_helper.clj
@@ -32,18 +32,6 @@
   (set-time! [this t]
     (reset! time t)))
 
-(defrecord NoOpDrift [clock]
-  component/Lifecycle
-  (start [this] this)
-  (stop [this] this)
-  drift/Drift
-  (drift! [this ts] nil)
-  (skewed-epoch! [this]
-    (drift/epoch! clock))
-  clojure.lang.IDeref
-  (deref [this]
-    0))
-
 (defrecord SynchronousQueue [consumers]
   component/Lifecycle
   (start [this]
@@ -65,7 +53,7 @@
   [config]
   (-> config
       (update :clock  #(map->TimeTravellingClock %))
-      (update :drift  #(component/using (map->NoOpDrift %) [:clock]))
+      (update :drift  #(component/using (drift/build-drift %) [:clock]))
       (update :queues map->SynchronousQueue)
       (update :index  index/build-index)
       (update :writer #(component/using (map->MemoryWriter %) [:index


### PR DESCRIPTION
Motivation: they use two different queues, and 
both can benefit from a bit of modularity for 
testing/maintenance.

I'm not absolutely sure about the naming: ingester migt be a bit too strict or specific. It might be that what is currently called ingester can be called Engine, as it was before. For that cause, for instance, the configuration files wouldn't need to be changed.