### PR TITLE
store and index: return a path key for backward compat

### DIFF
--- a/src/io/cyanite/index/cassandra.clj
+++ b/src/io/cyanite/index/cassandra.clj
@@ -54,6 +54,7 @@
   [pattern-length [path length leaf]]
   {:text          (last (split path #"\."))
    :id            path
+   :path          path
    :allowChildren (not leaf)
    :expandable    (not leaf)
    :leaf          leaf})


### PR DESCRIPTION
This fixes clients using cyanite through graphite-api, sorry!