### PR TITLE
Bugfix/fix wildcard queries

### DIFF
--- a/src/io/cyanite/query/ast.clj
+++ b/src/io/cyanite/query/ast.clj
@@ -120,7 +120,6 @@
      (let [safe-nil-subtract (nil-safe-op -)]
        (fn [[a b]] (safe-nil-subtract b a)))
      nil
-     ;; traverse input has to look like: (a.b.c [(nil (1 3) (3 6))])
      (mapcat (fn [[k v]] [k [(cons nil (partition 2 1 v))]])
              (partition 2 2
                         (resolve! series 1 1))))))

--- a/src/io/cyanite/store/pure.clj
+++ b/src/io/cyanite/store/pure.clj
@@ -33,7 +33,7 @@
   (let [n    (count points)
         time (-> points first :time)
         mean (/ (reduce + 0.0 (map (comp :mean :point) points)) n)
-        min  (reduce min (map (comp :min :point)points))
+        min  (reduce min (map (comp :min :point) points))
         max  (reduce max (map (comp :max :point) points))
         sum  (reduce + 0.0 (map (comp :sum :point) points))]
     (update (first points)

--- a/test/io/cyanite/integration/engine_test.clj
+++ b/test/io/cyanite/integration/engine_test.clj
@@ -1,0 +1,94 @@
+(ns io.cyanite.integration.engine-test
+  (:require [io.cyanite.store           :refer :all]
+            [io.cyanite.query          :refer :all]
+            [clojure.test               :refer :all]
+            [io.cyanite.test-helper     :refer :all]
+            [io.cyanite.engine          :as engine]
+            [io.cyanite.engine.rule     :as rule]
+            [io.cyanite.index           :as index]
+            [qbits.alia                 :as alia]))
+
+(defn mmap-vals
+  [f m]
+  (zipmap (keys m)
+          (map #(map f %) (vals m))))
+
+(defn map-vals
+  [f m]
+  (zipmap (keys m)
+          (map f (vals m))))
+
+(defn insert-data
+  [index store]
+  (doseq [[metric base] [["a.b.c" 10] ["a.b.d" 20]]] ;; "a.b.e"
+    (do
+      (index/register! index metric)
+      (doseq [i (range 1 100)]
+        (insert! store
+                 (engine/map->MetricSnapshot {:time (* 5 i)
+                                              :mean (+ base i)
+                                              :min  (+ base i)
+                                              :max  (+ base i)
+                                              :sum  (+ base i)
+                                              :path metric
+                                              :resolution (rule/map->Resolution {:precision 5 :period 3600})}))))))
+
+(defn cleanup-tables
+  [session]
+  (for [table ["metric" "path" "segment"]]
+    (alia/execute session (str "TRUNCATE TABLE " table))))
+
+(deftest index-prefixes-test
+  (with-config
+    {:engine {:rules {"default" ["5s:1h"]}}
+     :store {:cluster  "localhost"
+             :keyspace "cyanite_test"}
+     :index {:type     :cassandra
+             :cluster  "localhost"
+             :keyspace "cyanite_test"}}
+    {}
+    (let [index    (:index *system*)
+          store    (:store *system*)
+          engine   (:engine *system*)
+          session  (:session store)]
+      (insert-data index store)
+      (let [result (->> (run-query! store index engine 0 100 ["a.b.*"])
+                        (group-by :target)
+                        (mmap-vals :datapoints)
+                        (map-vals #(mapcat identity %))
+                        (map-vals #(map first %)))]
+        (is (= (map double (range 11 30))
+               (get result "a.b.c")))
+        (is (= (map double (range 21 40))
+               (get result "a.b.d"))))
+      (cleanup-tables store))))
+
+(deftest index-no-wildcard-test
+  (with-config
+    {:engine {:rules {"default" ["5s:1h"]}}
+     :store {:cluster  "localhost"
+             :keyspace "cyanite_test"}
+     :index {:type     :cassandra
+             :cluster  "localhost"
+             :keyspace "cyanite_test"}}
+    {}
+    (let [index    (:index *system*)
+          store    (:store *system*)
+          engine   (:engine *system*)
+          session  (:session store)]
+      (insert-data index store)
+      (let [result (->> (run-query! store index engine 0 100 ["a.b.c"])
+                        (group-by :target)
+                        (mmap-vals :datapoints)
+                        (map-vals #(mapcat identity %))
+                        (map-vals #(map first %)))]
+        (is (= (map double (range 11 30))
+               (get result "a.b.c"))))
+      (let [result (->> (run-query! store index engine 0 100 ["a.b.d"])
+                        (group-by :target)
+                        (mmap-vals :datapoints)
+                        (map-vals #(mapcat identity %))
+                        (map-vals #(map first %)))]
+        (is (= (map double (range 21 40))
+               (get result "a.b.d"))))
+      (cleanup-tables store))))

--- a/test/io/cyanite/query/ast_test.clj
+++ b/test/io/cyanite/query/ast_test.clj
@@ -9,33 +9,44 @@
               series))
 
 (deftest test-sum-series
-  (is (= (runq "sumSeries(f*)"
-               {"f*" [[1 1 1]
-                      [2 2 2]]})
-         ["sumSeries(f*)"
-          [[3 3 3]]])))
+  (is (= (runq "sumSeries(a.b.c,a.b.d)"
+               {"a.b.c" [1 1 1]
+                "a.b.d" [2 2 2]})
+         [["sumSeries(a.b.c,a.b.d)"
+           [3 3 3]]])))
 
 (deftest test-derivative
   (is (= (runq "derivative(a.b.c)"
-               {"a.b.c" [[1 3 6]]})
-         ["derivative(a.b.c)"
-          [[nil 2 3]]])))
+               {"a.b.c" [1 3 6]})
+         [["derivative(a.b.c)"
+           [nil 2 3]]])))
 
 (deftest test-absolute
   (is (= (runq "absolute(a.b.c)"
-               {"a.b.c" [[-1 -3 -6]]})
-         ["absolute(a.b.c)"
-          [[1 3 6]]])))
+               {"a.b.c" [-1 -3 -6]})
+         [["absolute(a.b.c)"
+           [1 3 6]]])))
 
-(deftest test-absolute
+(deftest test-scale
   (is (= (runq "scale(a.b.c,10.0)"
-               {"a.b.c" [[1 2 3]]})
-         ["scale(a.b.c,10.0)"
-          [[10.0 20.0 30.0]]])))
+               {"a.b.c" [1 2 3]})
+         [["scale(a.b.c,10.0)"
+           [10.0 20.0 30.0]]])))
 
 (deftest test-div
   (is (= (runq "divideSeries(a.b.c,a.b.d)"
-               {"a.b.c" [[10 20 30]]
-                "a.b.d" [[2 4 6]]})
-         ["divideSeries(a.b.c,a.b.d)"
-          [[5 5 5]]])))
+               {"a.b.c" [10 20 30]
+                "a.b.d" [2 4 6]})
+         [["divideSeries(a.b.c,a.b.d)"
+           [5 5 5]]])))
+
+(deftest test-path
+  (is (= (runq "a.b.*"
+               {"a.b.c" [10 20 30]
+                "a.b.d" [2 4 6]})
+         [["a.b.c" [10 20 30]]
+          ["a.b.d" [2 4 6]]]))
+  (is (= (runq "a.b.c"
+               {"a.b.c" [10 20 30]
+                "a.b.d" [2 4 6]})
+         [["a.b.c" [10 20 30]]])))

--- a/test/io/cyanite/query/ast_test.clj
+++ b/test/io/cyanite/query/ast_test.clj
@@ -13,25 +13,60 @@
                {"a.b.c" [1 1 1]
                 "a.b.d" [2 2 2]})
          [["sumSeries(a.b.c,a.b.d)"
+           [3 3 3]]]))
+  (is (= (runq "sumSeries(a.b.*)"
+               {"a.b.c" [1 1 1]
+                "a.b.d" [2 2 2]})
+         [["sumSeries(a.b.c,a.b.d)" [3 3 3]]])))
+
+(deftest test-sum-absolute-series
+  (is (= (runq "sumSeries(absolute(a.b.c),a.b.d)"
+               {"a.b.c" [1 1 1]
+                "a.b.d" [2 2 2]})
+         [["sumSeries(absolute(a.b.c),a.b.d)"
+           [3 3 3]]]))
+  (is (= (runq "sumSeries(a.b.*)"
+               {"a.b.c" [1 1 1]
+                "a.b.d" [2 2 2]})
+         [["sumSeries(a.b.c,a.b.d)"
            [3 3 3]]])))
 
 (deftest test-derivative
   (is (= (runq "derivative(a.b.c)"
                {"a.b.c" [1 3 6]})
          [["derivative(a.b.c)"
+           [nil 2 3]]]))
+  (is (= (runq "derivative(a.b.*)"
+               {"a.b.c" [1 3 6]
+                "a.b.d" [1 3 6]})
+         [["derivative(a.b.c)"
+           [nil 2 3]]
+          ["derivative(a.b.d)"
            [nil 2 3]]])))
 
 (deftest test-absolute
   (is (= (runq "absolute(a.b.c)"
                {"a.b.c" [-1 -3 -6]})
          [["absolute(a.b.c)"
-           [1 3 6]]])))
+           [1 3 6]]]))
+  (is (= (runq "absolute(a.b.*)"
+               {"a.b.c" [-1 -3 -5]
+                "a.b.d" [-1 -3 -6]})
+         [["absolute(a.b.c)" [1 3 5]]
+          ["absolute(a.b.d)" [1 3 6]]])))
 
 (deftest test-scale
   (is (= (runq "scale(a.b.c,10.0)"
                {"a.b.c" [1 2 3]})
          [["scale(a.b.c,10.0)"
-           [10.0 20.0 30.0]]])))
+           [10.0 20.0 30.0]]]))
+  (is (= (runq "scale(a.b.*,10.0)"
+               {"a.b.c" [1 2 3]
+                "a.b.d" [5 6 7]})
+         [["scale(a.b.c,10.0)"
+           [10.0 20.0 30.0]]
+          ["scale(a.b.d,10.0)"
+           [50.0 60.0 70.0]]])))
 
 (deftest test-div
   (is (= (runq "divideSeries(a.b.c,a.b.d)"

--- a/test/io/cyanite/query/ast_test.clj
+++ b/test/io/cyanite/query/ast_test.clj
@@ -20,3 +20,22 @@
                {"a.b.c" [[1 3 6]]})
          ["derivative(a.b.c)"
           [[nil 2 3]]])))
+
+(deftest test-absolute
+  (is (= (runq "absolute(a.b.c)"
+               {"a.b.c" [[-1 -3 -6]]})
+         ["absolute(a.b.c)"
+          [[1 3 6]]])))
+
+(deftest test-absolute
+  (is (= (runq "scale(a.b.c,10.0)"
+               {"a.b.c" [[1 2 3]]})
+         ["scale(a.b.c,10.0)"
+          [[10.0 20.0 30.0]]])))
+
+(deftest test-div
+  (is (= (runq "divideSeries(a.b.c,a.b.d)"
+               {"a.b.c" [[10 20 30]]
+                "a.b.d" [[2 4 6]]})
+         ["divideSeries(a.b.c,a.b.d)"
+          [[5 5 5]]])))

--- a/test/io/cyanite/query_test.clj
+++ b/test/io/cyanite/query_test.clj
@@ -25,19 +25,28 @@
         (when (= 0 (mod i 5))
           (e/snapshot! writer)))
 
-      (are [query result]
+      (is (= (run-query! store index engine base-time (+ base-time 60)
+                         ["a.b.*"])
+             [{:target "a.b.c" :datapoints [[2.0 base-time] [7.0 (+ base-time 5)]]}
+              {:target "a.b.d" :datapoints [[200.0 base-time] [700.0 (+ base-time 5)]]}
+              {:target "a.b.f" :datapoints [[2000.0 base-time] [7000.0 (+ base-time 5)]]}]))
+
+      (are [query expansion result]
           (= (run-query! store index engine base-time (+ base-time 60)
                          [query])
-             [{:target query :datapoints result}])
+             [{:target expansion :datapoints result}])
 
-        "a.b.c"
+        "a.b.c" "a.b.c"
         [[2.0 base-time] [7.0 (+ base-time 5)]]
 
-        "scale(a.b.c,2.0)"
+        "scale(a.b.c,2.0)" "scale(a.b.c,2.0)"
         [[4.0 base-time] [14.0 (+ base-time 5)]]
 
-        "derivative(a.b.c)"
+        "derivative(a.b.c)" "derivative(a.b.c)"
         [[5.0 (+ base-time 5)]]
 
-        "sumSeries(a.b.*)"
+        "sumSeries(a.b.c,a.b.d,a.b.f)" "sumSeries(a.b.c,a.b.d,a.b.f)"
+        [[2202.0 base-time] [7707.0 (+ base-time 5)]]
+
+        "sumSeries(a.b.*)" "sumSeries(a.b.c,a.b.d,a.b.f)"
         [[2202.0 base-time] [7707.0 (+ base-time 5)]]))))

--- a/test/io/cyanite/query_test.clj
+++ b/test/io/cyanite/query_test.clj
@@ -49,4 +49,5 @@
         [[2202.0 base-time] [7707.0 (+ base-time 5)]]
 
         "sumSeries(a.b.*)" "sumSeries(a.b.c,a.b.d,a.b.f)"
-        [[2202.0 base-time] [7707.0 (+ base-time 5)]]))))
+        [[2202.0 base-time] [7707.0 (+ base-time 5)]]
+        ))))


### PR DESCRIPTION
    Make sure that combined traversals work, split traversals for single and multi-series

    Queries need to work for several cases:

    1. When we combine series, sum
    2. When we map series, absolute
    3. When we reduce series, derivative
    4. Combination of any

    Since (1) is different from all the others, in the way it combines
    series and has to do (apply mapv ...), we have to make a separate
    function for it. FWIW, reducer and mapper _might_ be safely removed
    from there.

    To handle (2) and (3) in simpler way, `traverse-each!` was added,
    that handles operations on singlular series.