### PR TITLE
Prototype new scheduling system

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -24,7 +24,7 @@
                  [clj-yaml                      "0.4.0"]
                  [clj-time                      "0.11.0"]
                  [cc.qbits/alia                 "3.1.3"]
-                 [com.lmax/disruptor            "3.3.4"]
+                 [org.jctools/jctools-core      "1.2"]
                  [com.boundary/high-scale-lib   "1.0.6"]
                  [net.jpountz.lz4/lz4           "1.3"]
                  [org.xerial.snappy/snappy-java "1.1.2.1"]

--- a/src/io/cyanite.clj
+++ b/src/io/cyanite.clj
@@ -75,7 +75,7 @@
                                    :engine [:drift :queues :reporter :index]
                                    :index  []
                                    :store  []
-                                   :writer [:pool :store :engine :reporter]
+                                   :writer [:queues :pool :store :engine :reporter]
                                    :api    [:index :store :queues :engine :drift]})))))
 
 (defn -main

--- a/src/io/cyanite.clj
+++ b/src/io/cyanite.clj
@@ -59,7 +59,7 @@
       (start-logging! (merge config/default-logging (:logging config)))
       (-> (component/system-map
            :clock  (map->SystemClock {})
-           :queues (queue/map->BlockingMemoryQueue (:queue config))
+           :queues (queue/map->BlockingMemoryQueue {:options (:queue config)})
            :drift  (build-drift (:drift config))
            :engine (map->Engine (:engine config))
            :writer (map->Writer (:writer config))

--- a/src/io/cyanite/engine.clj
+++ b/src/io/cyanite/engine.clj
@@ -105,7 +105,7 @@
       (ingest! resolution metric)))
   Enqueuer
   (enqueue! [this metric]
-    (q/add! ingestq metric))
+    (q/engine-event! ingestq metric))
   Snapshoter
   (snapshot! [this]
     (snapshot! this (skewed-epoch! drift)))

--- a/src/io/cyanite/engine/queue.clj
+++ b/src/io/cyanite/engine/queue.clj
@@ -2,97 +2,78 @@
   "Queueing mechanism at the heart of cyanite."
   (:import java.util.concurrent.Executors
            java.util.ArrayList
-           com.lmax.disruptor.RingBuffer
-           com.lmax.disruptor.dsl.Disruptor
-           com.lmax.disruptor.EventFactory
-           com.lmax.disruptor.EventTranslatorOneArg
-           com.lmax.disruptor.ExceptionHandler
-           com.lmax.disruptor.EventHandler)
+           org.jctools.queues.SpscArrayQueue
+           org.jctools.queues.SpmcArrayQueue
+           )
   (:require [com.stuartsierra.component :as component]
             [spootnik.reporter          :as r]
             [clojure.tools.logging      :refer [warn error]]))
 
 
-(defonce default-poolsize 4)
+(defonce workers 4)
 (defonce default-capacity (int 1024))
 
 (defprotocol QueueEngine
   (shutdown! [this])
+  (start! [this])
   (consume! [this f])
-  (add! [this e]))
-
-(defn make-event-factory
-  [ctor]
-  (reify EventFactory
-    (newInstance [this]
-      (ctor))))
+  (engine-event! [this e])
+  (writer-event! [this e])
+  )
 
 (defn threadpool
   [sz]
   (Executors/newFixedThreadPool (int sz)))
 
-(defn disruptor
-  [event-factory size executor]
-  (Disruptor. event-factory (int size) executor))
-
-(defn make-translator
-  [f]
-  (reify EventTranslatorOneArg
-    (translateTo [this event sequence arg0]
-      (f event arg0))))
-
-(defn event-handler
-  [f]
-  (reify EventHandler
-    (onEvent [this event sequence eob]
-      (f @event))))
-
-(defn exception-handler
-  [f]
-  (reify ExceptionHandler
-    (handleEventException [this ex sequence event]
-      (f [ex event]))
-    (handleOnShutdownException [this ex]
-      ;; no-op
-      )
-    (handleOnStartException [this ex]
-      ;; no-op
-      )))
-
-(defrecord DisruptorQueue [disruptor translator alias reporter]
+(defrecord EngineQueue [alias reporter pool engine-queues writer-queue]
+  Object
+  (toString [_]
+    "EngineQueue")
   QueueEngine
   (shutdown! [this]
-    (.shutdown disruptor))
-  (add! [this e]
+    ;; (.shutdown disruptor)
+    )
+  (engine-event! [this e]
     (r/inc! reporter [:cyanite alias :events :ingested])
-    (.publishEvent disruptor translator e))
+    ;; TODO: implement Round-robin for more fair scheduling?
+    (.add (nth engine-queues (mod (hash e) workers)) e)
+    ;; (.publishEvent disruptor translator e)
+    )
+
+  (writer-event! [this e]
+    ;; (r/inc! reporter [:cyanite alias :events :ingested])
+    (.add writer-queue e)
+    ;; (.publishEvent disruptor translator e)
+    )
+  (start! [this]
+    )
   (consume! [this f]
-    (.handleEventsWith
-     disruptor
-     (into-array EventHandler
-                 [(event-handler (fn [e]
-                                   (try
-                                     (r/inc! reporter [:cyanite alias :events :processed])
-                                     (f e)
-                                     (catch Exception ex
-                                       (r/inc! reporter [:cyanite alias :errors])
-                                       (r/capture! reporter ex)))))]))
-    (.handleExceptionsWith
-     disruptor
-     (exception-handler (fn [[ex event]]
-                          (r/inc! reporter [:cyanite alias :errors])
-                          (r/capture! reporter ex))))
-    (.start disruptor)))
+    (doseq [queue engine-queues]
+      (.submit pool
+               (fn []
+                 (loop []
+                   (when-let [f (.poll writer-queue)]
+                     ;; TODO: poll-all-available?
+                     ;; TODO: exception handling
+                     ;; TODO: metrics
+                     (f))
+                   (when-let [el (.poll queue)]
+                     (f el))
+                   (recur))
+                 ))
+      )))
 
 (defn make-queue
   [defaults alias reporter]
   (let [capacity (or (:queue-capacity defaults) default-capacity)
-        pool     (threadpool (or (:pool-size defaults) default-poolsize))
-        factory  (make-event-factory #(volatile! nil))]
-    (DisruptorQueue. (disruptor factory capacity pool)
-                     (make-translator vreset!)
-                     alias
-                     reporter)))
+        workers  (or (:pool-size defaults) workers)
+        pool     (threadpool workers)]
+    (EngineQueue. alias
+                  reporter
+                  pool
+                  (take workers (repeatedly #(SpscArrayQueue. capacity)))
+                  (SpmcArrayQueue. capacity)
+                  )))
 
 (defrecord BlockingMemoryQueue [ingestq defaults reporter]
   component/Lifecycle

--- a/test/io/cyanite/test_helper.clj
+++ b/test/io/cyanite/test_helper.clj
@@ -39,7 +39,10 @@
 (defrecord SynchronousQueueEngine [consumers]
   queue/QueueEngine
   (shutdown! [this])
-  (add! [this e]
+  (engine-event! [this e]
+    (doseq [f @consumers]
+      (f e)))
+  (writer-event! [this e]
     (doseq [f @consumers]
       (f e)))
   (consume! [this f]


### PR DESCRIPTION
The biggest problems with event processing we faced so far is 
that the consumer queues get overwhelmed and start pushing 
the writer queue way behind. 

This patch implements a micro-scheduling system (currently 
extremely primitive), that's using queue-per-core that polls
and processes writer flushes from every worker process and "regular"
digested events (currently in non-numa-aware fashion & without
thread affinity) via single-producer-single-consumer queues.

For example, 4 workers are started, each worker has an affine
single producer (netty event loop) single consumer (worker thread)
queue. It polls events from it and ingests them.

Every worker, prior to polling it's queue, checks if there are
any pending flushes / database writes. If there are any, it
submits them. Results are collected asynchronously.

This will help us to move at least part of cyanite that's related
to writes to more predictable / controllable env. Also, we can
further improve it, make it numa-aware and make scheduling and
back-pressure smarter.