### PR TITLE
Simplify indexes, remove paths table

### DIFF
--- a/doc/schema.cql
+++ b/doc/schema.cql
@@ -36,28 +36,6 @@ CREATE TABLE IF NOT EXISTS metric (
   AND read_repair_chance = 0.0
   AND speculative_retry = '99.0PERCENTILE';
 
-CREATE TABLE IF NOT EXISTS path (
-    prefix text,
-    path text,
-    length int,
-    PRIMARY KEY (prefix, path)
-) WITH bloom_filter_fp_chance = 0.01
-    AND caching = {'keys':'ALL', 'rows_per_partition':'NONE'}
-    AND comment = ''
-    AND compaction = {'class': 'org.apache.cassandra.db.compaction.SizeTieredCompactionStrategy'}
-    AND compression = {'sstable_compression': 'org.apache.cassandra.io.compress.LZ4Compressor'}
-    AND dclocal_read_repair_chance = 0.1
-    AND default_time_to_live = 0
-    AND gc_grace_seconds = 864000
-    AND max_index_interval = 2048
-    AND memtable_flush_period_in_ms = 0
-    AND min_index_interval = 128
-    AND read_repair_chance = 0.0
-    AND speculative_retry = '99.0PERCENTILE';
-
-CREATE CUSTOM INDEX IF NOT EXISTS on path(path) USING 'org.apache.cassandra.index.sasi.SASIIndex' WITH OPTIONS = {'mode': 'PREFIX'};
-CREATE CUSTOM INDEX IF NOT EXISTS on path(length) USING 'org.apache.cassandra.index.sasi.SASIIndex';
-
 CREATE TABLE IF NOT EXISTS segment (
     parent text,
     segment text,

--- a/src/io/cyanite/query.clj
+++ b/src/io/cyanite/query.clj
@@ -13,7 +13,7 @@
 (defn path-leaves
   [index paths]
   (zipmap paths
-          (map #(index/leaves index %) paths)))
+          (map #(index/prefixes index %) paths)))
 
 (defn merge-paths
   [by-path series]

--- a/test/io/cyanite/integration/engine_test.clj
+++ b/test/io/cyanite/integration/engine_test.clj
@@ -35,7 +35,7 @@
 
 (defn cleanup-tables
   [session]
-  (doseq [table ["metric" "path" "segment"]]
+  (doseq [table ["metric" "segment"]]
     (alia/execute session (str "TRUNCATE TABLE " table))))
 
 (deftest index-prefixes-test

--- a/test/io/cyanite/integration/index_test.clj
+++ b/test/io/cyanite/integration/index_test.clj
@@ -3,25 +3,17 @@
             [clojure.test               :refer :all]
             [io.cyanite.test-helper     :refer :all]
             [io.cyanite.index           :as index]
-            [qbits.alia                 :as alia]
-            [clj-time.core :as t]))
+            [qbits.alia                 :as alia]))
 
 (defn cleanup-tables
   [session]
-  (doseq [table ["metric" "path" "segment"]]
-    (alia/execute session (str "TRUNCATE TABLE " table))))
+  (alia/execute session (str "TRUNCATE TABLE segment")))
 
-(deftest index-prefixes-test
-  (with-config
-    {:store {:cluster  "localhost"
-             :keyspace "cyanite_test"}
-     :index {:type     :cassandra
-             :cluster  "localhost"
-             :keyspace "cyanite_test"}}
-    {}
-    (let [index    (:index *system*)
-          store    (:store *system*)
-          session  (:session store)]
+(defn test-index
+  []
+  (let [index    (:index *system*)
+        store    (:store *system*)
+        session  (:session store)]
       (cleanup-tables session)
       (index/register! index "aa.bb.cc")
       (index/register! index "aa.bb.dd")
@@ -42,15 +34,23 @@
              (set (map :id (index/prefixes index "bb.*")))))
       (is (= #{"aa.bb" "cc.bb"}
              (set (map :id (index/prefixes index "*.bb")))))
+      (is (= #{"aa.bb.cc" "aa.bb.dd" "cc.bb.cc" "cc.bb.dd"}
+             (set (map :id (index/prefixes index "*.bb.*")))))
+      (is (= #{"aa.bb.dd" "cc.bb.dd"}
+             (set (map :id (index/prefixes index "*.*.dd")))))
+      (is (= #{"cc.bb.cc" "cc.ee.cc" "cc.ff.cc" "cc.gg.cc" "cc.hh.cc"}
+             (set (map :id (index/prefixes index "cc.*.cc")))))
+      (is (= #{"aa.ee.cc" "cc.ee.cc"}
+             (set (map :id (index/prefixes index "*.ee.cc")))))
       (is (= #{"aa" "cc"}
              (set (map :id (index/prefixes index "*")))))
       (is (= #{"aa.ee.cc" "aa.hh.cc" "aa.bb.cc" "aa.ff.cc" "aa.gg.cc"}
              (set (map :id (index/prefixes index "aa.*.cc")))))
       (is (= #{"aa.ee.cc"}
              (set (map :id (index/prefixes index "aa.ee.cc")))))
-      (cleanup-tables session))))
+      (cleanup-tables session)))
 
-(deftest leaves-test
+(deftest sasi-index-test
   (with-config
     {:store {:cluster  "localhost"
              :keyspace "cyanite_test"}
@@ -58,22 +58,12 @@
              :cluster  "localhost"
              :keyspace "cyanite_test"}}
     {}
-    (let [index    (:index *system*)
-          store    (:store *system*)
-          session  (:session store)]
-      (cleanup-tables session)
-      (index/register! index "a.b.c")
-      (index/register! index "a.b.d")
-      (index/register! index "a.e.c")
-      (index/register! index "a.f.c")
-      (index/register! index "a.g.c")
-      (index/register! index "a.h.c")
+    (test-index)))
 
-      (is (= ["a.b.c" "a.b.d"]
-             (map :path (index/leaves index "a.b.*"))))
-      (is (= ["a.e.c"]
-             (map :path (index/leaves index "a.e.*"))))
-      (is (= []
-             (map :path (index/leaves index "a.z.*"))))
-
-      (cleanup-tables session))))
+(deftest agent-index-test
+  (with-config
+    {:store {:cluster  "localhost"
+             :keyspace "cyanite_test"}
+     :index {:type     :atom}}
+    {}
+    (test-index)))


### PR DESCRIPTION
Paths table is redundant and was slowing down both write
and read path, since it was much harder to simplify it.
It was initially an artefact of having leaves and prefixes
queries, although after optimising the query building,
it's all not required and will allow for faster queries.